### PR TITLE
Create GetChildBounds method 

### DIFF
--- a/Octree.Tests/BoundOctreeTest.cs
+++ b/Octree.Tests/BoundOctreeTest.cs
@@ -6,11 +6,11 @@
 
 namespace Octree.Tests
 {
+    using Shouldly;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Numerics;
-    using Shouldly;
     using Xunit;
 
     public class BoundOctreeTest
@@ -105,7 +105,7 @@ namespace Octree.Tests
             _octree.GetColliding(new BoundingBox(new Vector3(50), new Vector3(50))).Length.ShouldBe(51);
 
             // Non-alloc test
-            List<int> result = new List<int>(new[] {999});
+            List<int> result = new List<int>(new[] { 999 });
             _octree.GetCollidingNonAlloc(result, new BoundingBox(new Vector3(50), new Vector3(50))).ShouldBeTrue();
             result.Count.ShouldBe(51);
         }
@@ -163,6 +163,23 @@ namespace Octree.Tests
             for (int i = 1; i < 100; ++i)
                 _octree.Remove(i, new BoundingBox(new Vector3(i), new Vector3(0.5f))).ShouldBeTrue();
             _octree.Count.ShouldBe(0);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="BoundsOctree{T}.GetChildBounds" /> method.
+        /// </summary>
+        [Fact]
+        public void ChildBoundsTest()
+        {
+            // Should be only one bound
+            _octree.GetChildBounds().Length.ShouldBe(1);
+
+            // Add points
+            for (int i = 1; i < 100; ++i)
+                _octree.Add(i, new BoundingBox(new Vector3(i), Vector3.One));
+
+            // Should be 127 bound
+            _octree.GetChildBounds().Length.ShouldBe(127);
         }
     }
 }

--- a/Octree.Tests/PointOctreeTest.cs
+++ b/Octree.Tests/PointOctreeTest.cs
@@ -6,11 +6,11 @@
 
 namespace Octree.Tests
 {
+    using Shouldly;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Numerics;
-    using Shouldly;
     using Xunit;
 
     public class PointOctreeTest
@@ -140,6 +140,23 @@ namespace Octree.Tests
             for (int i = 1; i < 100; ++i)
                 _octree.Remove(i, new Vector3(i)).ShouldBeTrue();
             _octree.Count.ShouldBe(0);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="BoundsOctree{T}.GetChildBounds" /> method.
+        /// </summary>
+        [Fact]
+        public void ChildBoundsTest()
+        {
+            // Should be only one bound
+            _octree.GetChildBounds().Length.ShouldBe(1);
+
+            // Add points
+            for (int i = 1; i < 100; ++i)
+                _octree.Add(i, new Vector3(i));
+
+            // Should be 127 bound
+            _octree.GetChildBounds().Length.ShouldBe(127);
         }
     }
 }

--- a/Octree/BoundsOctree.cs
+++ b/Octree/BoundsOctree.cs
@@ -7,9 +7,9 @@
 // </copyright>
 namespace Octree
 {
+    using NLog;
     using System.Collections.Generic;
     using System.Numerics;
-    using NLog;
 
     /// <summary>
     /// A Dynamic, Loose Octree for storing any objects that can be described with AABB bounds
@@ -65,18 +65,27 @@ namespace Octree
         /// </summary>
         private readonly float _minSize;
 
-	    /// <summary>
-	    /// The total amount of objects currently in the tree
-	    /// </summary>
-	    public int Count { get; private set; }
+        /// <summary>
+        /// The total amount of objects currently in the tree
+        /// </summary>
+        public int Count { get; private set; }
 
-		/// <summary>
-		/// Gets the bounding box that represents the whole octree
-		/// </summary>
-		/// <value>The bounding box of the root node.</value>
-		public BoundingBox MaxBounds
+        /// <summary>
+        /// Gets the bounding box that represents the whole octree
+        /// </summary>
+        /// <value>The bounding box of the root node.</value>
+        public BoundingBox MaxBounds
         {
             get { return _rootNode.Bounds; }
+        }
+
+        /// <summary>
+        /// Gets All the bounding box that represents the whole octree
+        /// </summary>
+        /// <returns></returns>
+        public BoundingBox[] GetChildBounds()
+        {
+            return _rootNode.GetChildBounds().ToArray();
         }
 
         /// <summary>

--- a/Octree/BoundsOctree.cs
+++ b/Octree/BoundsOctree.cs
@@ -85,7 +85,9 @@ namespace Octree
         /// <returns></returns>
         public BoundingBox[] GetChildBounds()
         {
-            return _rootNode.GetChildBounds().ToArray();
+            var bounds = new List<BoundingBox>();
+            _rootNode.GetChildBounds(bounds);
+            return bounds.ToArray();
         }
 
         /// <summary>

--- a/Octree/BoundsOctreeNode.cs
+++ b/Octree/BoundsOctreeNode.cs
@@ -7,9 +7,9 @@
 // </copyright>
 namespace Octree
 {
+    using NLog;
     using System.Collections.Generic;
     using System.Numerics;
-    using NLog;
 
     public partial class BoundsOctree<T>
     {
@@ -106,6 +106,26 @@ namespace Octree
             public BoundingBox Bounds
             {
                 get { return _bounds; }
+            }
+
+            /// <summary>
+            /// Gets All the bounding box that represents this node
+            /// </summary>
+            /// <returns></returns>
+            public List<BoundingBox> GetChildBounds()
+            {
+                var list = new List<BoundingBox>();
+                if (HasChildren)
+                {
+                    foreach (var child in _children)
+                    {
+                        list.AddRange(child.GetChildBounds());
+                    }
+                    return list;
+                }
+
+                list.Add(Bounds);
+                return list;
             }
 
             /// <summary>

--- a/Octree/BoundsOctreeNode.cs
+++ b/Octree/BoundsOctreeNode.cs
@@ -111,21 +111,18 @@ namespace Octree
             /// <summary>
             /// Gets All the bounding box that represents this node
             /// </summary>
-            /// <returns></returns>
-            public List<BoundingBox> GetChildBounds()
+            /// <param name="bounds"></param>
+            public void GetChildBounds(List<BoundingBox> bounds)
             {
-                var list = new List<BoundingBox>();
                 if (HasChildren)
                 {
                     foreach (var child in _children)
                     {
-                        list.AddRange(child.GetChildBounds());
+                        child.GetChildBounds(bounds);
                     }
-                    return list;
+                    return;
                 }
-
-                list.Add(Bounds);
-                return list;
+                bounds.Add(Bounds);
             }
 
             /// <summary>

--- a/Octree/PointOctree.cs
+++ b/Octree/PointOctree.cs
@@ -69,7 +69,9 @@ namespace Octree
         /// <returns></returns>
         public BoundingBox[] GetChildBounds()
         {
-            return _rootNode.GetChildBounds().ToArray();
+            var bounds = new List<BoundingBox>();
+            _rootNode.GetChildBounds(bounds);
+            return bounds.ToArray();
         }
 
         /// <summary>

--- a/Octree/PointOctree.cs
+++ b/Octree/PointOctree.cs
@@ -7,9 +7,9 @@
 // </copyright>
 namespace Octree
 {
+    using NLog;
     using System.Collections.Generic;
     using System.Numerics;
-    using NLog;
 
     /// <summary>
     /// A Dynamic Octree for storing any objects that can be described as a single point
@@ -49,27 +49,36 @@ namespace Octree
         /// </summary>
         private readonly float _minSize;
 
-	    /// <summary>
-	    /// The total amount of objects currently in the tree
-	    /// </summary>
-	    public int Count { get; private set; }
+        /// <summary>
+        /// The total amount of objects currently in the tree
+        /// </summary>
+        public int Count { get; private set; }
 
-	    /// <summary>
-	    /// Gets the bounding box that represents the whole octree
-	    /// </summary>
-	    /// <value>The bounding box of the root node.</value>
-	    public BoundingBox MaxBounds
-	    {
-		    get { return new BoundingBox(_rootNode.Center, new Vector3(_rootNode.SideLength, _rootNode.SideLength, _rootNode.SideLength)); }
-	    }
+        /// <summary>
+        /// Gets the bounding box that represents the whole octree
+        /// </summary>
+        /// <value>The bounding box of the root node.</value>
+        public BoundingBox MaxBounds
+        {
+            get { return new BoundingBox(_rootNode.Center, new Vector3(_rootNode.SideLength, _rootNode.SideLength, _rootNode.SideLength)); }
+        }
 
-		/// <summary>
-		/// Constructor for the point octree.
-		/// </summary>
-		/// <param name="initialWorldSize">Size of the sides of the initial node. The octree will never shrink smaller than this.</param>
-		/// <param name="initialWorldPos">Position of the centre of the initial node.</param>
-		/// <param name="minNodeSize">Nodes will stop splitting if the new nodes would be smaller than this.</param>
-		public PointOctree(float initialWorldSize, Vector3 initialWorldPos, float minNodeSize)
+        /// <summary>
+        /// Gets All the bounding box that represents the whole octree
+        /// </summary>
+        /// <returns></returns>
+        public BoundingBox[] GetChildBounds()
+        {
+            return _rootNode.GetChildBounds().ToArray();
+        }
+
+        /// <summary>
+        /// Constructor for the point octree.
+        /// </summary>
+        /// <param name="initialWorldSize">Size of the sides of the initial node. The octree will never shrink smaller than this.</param>
+        /// <param name="initialWorldPos">Position of the centre of the initial node.</param>
+        /// <param name="minNodeSize">Nodes will stop splitting if the new nodes would be smaller than this.</param>
+        public PointOctree(float initialWorldSize, Vector3 initialWorldPos, float minNodeSize)
         {
             if (minNodeSize > initialWorldSize)
             {

--- a/Octree/PointOctreeNode.cs
+++ b/Octree/PointOctreeNode.cs
@@ -107,21 +107,18 @@ namespace Octree
             /// <summary>
             /// Gets All the bounding box that represents this node
             /// </summary>
-            /// <returns></returns>
-            public List<BoundingBox> GetChildBounds()
+            /// <param name="bounds"></param>
+            public void GetChildBounds(List<BoundingBox> bounds)
             {
-                var list = new List<BoundingBox>();
                 if (HasChildren)
                 {
                     foreach (var child in _children)
                     {
-                        list.AddRange(child.GetChildBounds());
+                        child.GetChildBounds(bounds);
                     }
-                    return list;
+                    return;
                 }
-
-                list.Add(Bounds);
-                return list;
+                bounds.Add(Bounds);
             }
 
             /// <summary>

--- a/Octree/PointOctreeNode.cs
+++ b/Octree/PointOctreeNode.cs
@@ -7,10 +7,10 @@
 // </copyright>
 namespace Octree
 {
+    using NLog;
     using System.Collections.Generic;
     using System.Linq;
     using System.Numerics;
-    using NLog;
 
     public partial class PointOctree<T>
     {
@@ -94,6 +94,34 @@ namespace Octree
                 /// Object position
                 /// </summary>
                 public Vector3 Pos;
+            }
+
+            /// <summary>
+            /// Gets the bounding box that represents this node
+            /// </summary>
+            public BoundingBox Bounds
+            {
+                get { return _bounds; }
+            }
+
+            /// <summary>
+            /// Gets All the bounding box that represents this node
+            /// </summary>
+            /// <returns></returns>
+            public List<BoundingBox> GetChildBounds()
+            {
+                var list = new List<BoundingBox>();
+                if (HasChildren)
+                {
+                    foreach (var child in _children)
+                    {
+                        list.AddRange(child.GetChildBounds());
+                    }
+                    return list;
+                }
+
+                list.Add(Bounds);
+                return list;
             }
 
             /// <summary>


### PR DESCRIPTION
Features:
* Add `GetChildBounds` method to get all the bounding box that represents the whole octree.
* Add Tests `ChildBoundsTest`

I create the GetChildBounds method to get all the bounding box that represents the whole octree so is able to visualize all the boxes.

![Octree](https://user-images.githubusercontent.com/12437519/187083981-616aec4a-002e-4f7f-a20a-89607080b5e1.PNG)




